### PR TITLE
Fix kernel version logic in Makefiles

### DIFF
--- a/modules/goodix_ts/Makefile
+++ b/modules/goodix_ts/Makefile
@@ -1,5 +1,5 @@
 DKMS_NAME = goodix_ts
-KVER ?= $(shell uname -r | cut -d- -f1)
+KVER ?= $(shell uname -r | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
 DKMS_VERSION = $(KVER)-minibook1
 DKMS_DIR = /usr/src/$(DKMS_NAME)-$(DKMS_VERSION)
 KERNEL_GIT = https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain

--- a/vbt_patch/Makefile
+++ b/vbt_patch/Makefile
@@ -1,7 +1,7 @@
 CC = clang
 CFLAGS = -Wall -Wextra -O2
 
-KVER ?= $(shell uname -r | cut -d- -f1)
+KVER ?= $(shell uname -r | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
 KERNEL_GIT = https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain
 I915_DISPLAY = drivers/gpu/drm/i915/display
 HEADERS = intel_vbt_defs.h intel_dsi_vbt_defs.h


### PR DESCRIPTION
Addresses issue with debian version strings which have a suffix e.g. `6.12.86+deb13`