### PR TITLE
Non-LLVM compatibility + expose keyboard backlight events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,13 @@ Every installable component should have a `Makefile` with `install` and
 - Follow the official Linux kernel coding style
   (`Documentation/process/coding-style.rst`)
 - Build with `make` (standard kbuild `obj-m` pattern)
-- Use `LLVM=1` for clang builds (sets CC, LD, AR, NM, etc.)
+- `dkms.conf` files detect the target kernel's compiler at build time via a
+  `LLVM_FLAG=$(grep -sq CC_IS_CLANG=y ${kernel_source_dir}/.config && echo
+  LLVM=1)` line; the value (either `LLVM=1` or empty) is interpolated into
+  `MAKE[0]`. This picks `LLVM=1` for clang-built kernels (CachyOS, some Arch
+  builds, …) and gcc for everyone else (Debian, RHEL, openSUSE, …), and works
+  for DKMS auto-rebuild on kernel upgrades because the check reads the *target*
+  kernel's `.config`.
 - Include `dkms.conf` for DKMS packaging
 - When patching an existing upstream driver: `make` downloads the kernel
   source files for the running kernel version and applies a `.patch`;

--- a/docs/minibook-ec.md
+++ b/docs/minibook-ec.md
@@ -192,6 +192,22 @@ restores the last brightness level.
 `auto_off_timer = 0` keeps the backlight on indefinitely regardless of keyboard
 activity. This matches the BIOS setting "Keyboard Backlight Mode = Always on."
 
+#### Tracking EC-initiated changes (opt-in)
+
+Enable the `poll_hw_changed` module parameter to have GNOME/KDE/etc. track
+brightness changes triggered by the dedicated backlight toggle key or the
+auto-off timer:
+
+```
+echo 'options minibook_ec poll_hw_changed=1' \
+  | sudo tee /etc/modprobe.d/minibook_ec.conf
+```
+
+This adds a `brightness_hw_changed` attribute under the LED node. UPower
+watches it via `poll(2)`/`POLLPRI` and re-broadcasts changes over D-Bus, which
+is what desktop environments listen to for "the keyboard backlight changed."
+Off by default because it requires a 250 ms in-kernel poll of the EC.
+
 ### Sysfs attributes
 
 Four attributes appear under the platform device

--- a/modules/dptf_enabler/dkms.conf
+++ b/modules/dptf_enabler/dkms.conf
@@ -3,5 +3,6 @@ PACKAGE_VERSION="1.0"
 BUILT_MODULE_NAME[0]="dptf_enabler"
 DEST_MODULE_LOCATION[0]="/kernel/drivers/acpi"
 AUTOINSTALL="yes"
-MAKE[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build LLVM=1 modules"
+LLVM_FLAG=$(grep -sq CC_IS_CLANG=y ${kernel_source_dir}/.config && echo LLVM=1)
+MAKE[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build ${LLVM_FLAG} modules"
 CLEAN="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"

--- a/modules/goodix_ts/Makefile
+++ b/modules/goodix_ts/Makefile
@@ -1,5 +1,6 @@
 DKMS_NAME = goodix_ts
 KVER ?= $(shell uname -r | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
+KVER_MM ?= $(shell uname -r | grep -oE '^[0-9]+\.[0-9]+')
 DKMS_VERSION = $(KVER)-minibook1
 DKMS_DIR = /usr/src/$(DKMS_NAME)-$(DKMS_VERSION)
 KERNEL_GIT = https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain
@@ -9,7 +10,7 @@ SOURCES = goodix.c goodix.h goodix_fwupload.c
 all: .patched.stamp
 
 $(SOURCES):
-	curl -fsSL -o $@ "$(KERNEL_GIT)/$(TOUCHSCREEN_DIR)/$@?h=v$(KVER)"
+	curl -fsSL -o $@ "$(KERNEL_GIT)/$(TOUCHSCREEN_DIR)/$@?h=linux-$(KVER_MM).y"
 
 .patched.stamp: $(SOURCES) goodix_resume.patch
 	patch -N -p1 < goodix_resume.patch || true

--- a/modules/goodix_ts/dkms.conf
+++ b/modules/goodix_ts/dkms.conf
@@ -3,5 +3,6 @@ PACKAGE_VERSION="minibook1"
 BUILT_MODULE_NAME[0]="goodix_ts"
 DEST_MODULE_LOCATION[0]="/kernel/drivers/input/touchscreen"
 AUTOINSTALL="yes"
-MAKE[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build LLVM=1 modules"
+LLVM_FLAG=$(grep -sq CC_IS_CLANG=y ${kernel_source_dir}/.config && echo LLVM=1)
+MAKE[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build ${LLVM_FLAG} modules"
 CLEAN="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"

--- a/modules/goodix_ts/goodix_resume.patch
+++ b/modules/goodix_ts/goodix_resume.patch
@@ -88,6 +88,3 @@
  	if (!error && config_ver != ts->config[0])
  		dev_info(dev, "Config version mismatch %d != %d, resetting controller\n",
  			 config_ver, ts->config[0]);
-@@ -1577,3 +1620,3 @@ MODULE_AUTHOR("Bastien Nocera <hadess@hadess.net>");
- MODULE_DESCRIPTION("Goodix touchscreen driver");
- MODULE_LICENSE("GPL v2");

--- a/modules/i2c_designware_spklen/dkms.conf
+++ b/modules/i2c_designware_spklen/dkms.conf
@@ -3,5 +3,6 @@ PACKAGE_VERSION="1.0"
 BUILT_MODULE_NAME[0]="i2c_designware_spklen"
 DEST_MODULE_LOCATION[0]="/kernel/drivers/i2c/busses"
 AUTOINSTALL="yes"
-MAKE[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build LLVM=1 modules"
+LLVM_FLAG=$(grep -sq CC_IS_CLANG=y ${kernel_source_dir}/.config && echo LLVM=1)
+MAKE[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build ${LLVM_FLAG} modules"
 CLEAN="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"

--- a/modules/minibook_ec/dkms.conf
+++ b/modules/minibook_ec/dkms.conf
@@ -3,5 +3,6 @@ PACKAGE_VERSION="1.0"
 BUILT_MODULE_NAME[0]="minibook_ec"
 DEST_MODULE_LOCATION[0]="/kernel/drivers/platform/x86"
 AUTOINSTALL="yes"
-MAKE[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build LLVM=1 modules"
+LLVM_FLAG=$(grep -sq CC_IS_CLANG=y ${kernel_source_dir}/.config && echo LLVM=1)
+MAKE[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build ${LLVM_FLAG} modules"
 CLEAN="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"

--- a/modules/minibook_ec/minibook_ec_kbd_backlight.c
+++ b/modules/minibook_ec/minibook_ec_kbd_backlight.c
@@ -20,15 +20,31 @@
  * expiry the firmware closes the gate. Keyboard activity re-arms it.
  * auto_off_timer == 0 → writes 0x0411 = 0xEE; firmware skips the decrement,
  * matching BIOS "Keyboard Backlight Mode = Always on".
+ *
+ * The EC firmware silently mutates the LED on its own (BIOS-defined Fn-key
+ * toggles brightness, auto-off timer closes the gate). It does not raise an
+ * SCI / ACPI Notify, so the host learns about EC-initiated changes only by
+ * reading the PWM. The optional poll_hw_changed module parameter enables a
+ * 250 ms delayed_work that surfaces deltas via LED_BRIGHT_HW_CHANGED so
+ * UPower / GNOME / KDE can pick them up; off by default.
  */
 
 #include <linux/device.h>
+#include <linux/devm-helpers.h>
 #include <linux/errno.h>
+#include <linux/jiffies.h>
 #include <linux/kernel.h>
 #include <linux/leds.h>
+#include <linux/moduleparam.h>
 #include <linux/sysfs.h>
+#include <linux/workqueue.h>
 
 #include "minibook_ec.h"
+
+static bool poll_hw_changed;
+module_param(poll_hw_changed, bool, 0444);
+MODULE_PARM_DESC(poll_hw_changed,
+		 "Opt in to polling the EC and surfacing EC-initiated brightness changes via the LED-class brightness_hw_changed attribute (default: off)");
 
 #define IT5570E_KBD_BL_DCR		0x1803
 #define IT5570E_KBD_BL_GPIO_GATE	0x1611
@@ -40,10 +56,13 @@
 
 #define KBD_BL_MAX_BRIGHTNESS		0xFF
 #define KBD_BL_LED_NAME			"minibook::kbd_backlight"
+#define KBD_BL_POLL_INTERVAL		(HZ / 4)
 
 struct kbd_backlight {
 	struct led_classdev cdev;
 	struct minibook_ec *ec;
+	struct delayed_work poll_work;
+	u8 last_observed;
 };
 
 static struct kbd_backlight *dev_to_kbl(struct device *dev)
@@ -104,11 +123,13 @@ static void kbd_bl_set_auto_off(struct minibook_ec *ec, bool enable)
 static int kbd_bl_brightness_set(struct led_classdev *cdev,
 				 enum led_brightness value)
 {
-	struct minibook_ec *ec = cdev_to_ec(cdev);
+	struct kbd_backlight *kbl =
+		container_of(cdev, struct kbd_backlight, cdev);
 
-	kbd_bl_set_duty(ec, value);
-	if (kbd_bl_timer_suspended(ec))
-		kbd_bl_set_output(ec, value != 0);
+	kbd_bl_set_duty(kbl->ec, value);
+	if (kbd_bl_timer_suspended(kbl->ec))
+		kbd_bl_set_output(kbl->ec, value != 0);
+	kbl->last_observed = value;
 	return 0;
 }
 
@@ -119,6 +140,23 @@ static enum led_brightness kbd_bl_brightness_get(struct led_classdev *cdev)
 	if (kbd_bl_output_gated(ec))
 		return LED_OFF;
 	return minibook_ec_i2ec_read(ec, IT5570E_KBD_BL_DCR);
+}
+
+static void kbd_bl_poll_work(struct work_struct *work)
+{
+	struct kbd_backlight *kbl = container_of(to_delayed_work(work),
+						 struct kbd_backlight,
+						 poll_work);
+	enum led_brightness current_bri = kbd_bl_brightness_get(&kbl->cdev);
+
+	if (current_bri != kbl->last_observed) {
+		kbl->last_observed = current_bri;
+		led_classdev_notify_brightness_hw_changed(&kbl->cdev,
+							  current_bri);
+	}
+
+	queue_delayed_work(system_power_efficient_wq, &kbl->poll_work,
+			   round_jiffies_relative(KBD_BL_POLL_INTERVAL));
 }
 
 static ssize_t auto_off_timer_show(struct device *dev,
@@ -157,6 +195,7 @@ ATTRIBUTE_GROUPS(kbd_bl);
 int minibook_ec_register_kbd_backlight(struct minibook_ec *ec)
 {
 	struct kbd_backlight *kbl;
+	int ret;
 
 	if (!ec->pnpcfg_available)
 		return -ENODEV;
@@ -172,7 +211,24 @@ int minibook_ec_register_kbd_backlight(struct minibook_ec *ec)
 	kbl->cdev.brightness_get = kbd_bl_brightness_get;
 	kbl->cdev.groups = kbd_bl_groups;
 	kbl->cdev.flags = LED_CORE_SUSPENDRESUME;
+	if (poll_hw_changed)
+		kbl->cdev.flags |= LED_BRIGHT_HW_CHANGED;
 
 	ec->kbd_bl = kbl;
-	return devm_led_classdev_register(&ec->pdev->dev, &kbl->cdev);
+	ret = devm_led_classdev_register(&ec->pdev->dev, &kbl->cdev);
+	if (ret)
+		return ret;
+
+	if (!poll_hw_changed)
+		return 0;
+
+	kbl->last_observed = kbd_bl_brightness_get(&kbl->cdev);
+	ret = devm_delayed_work_autocancel(&ec->pdev->dev, &kbl->poll_work,
+					   kbd_bl_poll_work);
+	if (ret)
+		return ret;
+
+	queue_delayed_work(system_power_efficient_wq, &kbl->poll_work,
+			   round_jiffies_relative(KBD_BL_POLL_INTERVAL));
+	return 0;
 }

--- a/vbt_patch/Makefile
+++ b/vbt_patch/Makefile
@@ -1,8 +1,7 @@
 CC = clang
 CFLAGS = -Wall -Wextra -O2
 
-KVER ?= $(shell uname -r | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
-KERNEL_GIT = https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain
+KERNEL_GIT = https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/plain
 I915_DISPLAY = drivers/gpu/drm/i915/display
 HEADERS = intel_vbt_defs.h intel_dsi_vbt_defs.h
 
@@ -10,7 +9,7 @@ vbt_patch: vbt_patch.c $(HEADERS)
 	$(CC) $(CFLAGS) -o $@ vbt_patch.c
 
 $(HEADERS):
-	curl -fsSL -o $@ "$(KERNEL_GIT)/$(I915_DISPLAY)/$@?h=v$(KVER)"
+	curl -fsSL -o $@ "$(KERNEL_GIT)/$(I915_DISPLAY)/$@"
 
 all: vbt_patch
 


### PR DESCRIPTION
This is a subset of #7 by @victorewik with just the changes to `Makefile`s for Debian compatibility + polling for the EC module.