### PR TITLE
Make iio-sensor-proxy always emit tablet events

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+charset = utf-8
+insert_final_newline = true
+end_of_line = lf
+indent_style = space
+indent_size = 2
+max_line_length = 120

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -373,12 +373,16 @@ for faster wake times.
 ### S3 (deep) - hardware sleep
 
 Traditional suspend-to-RAM. The system powers down everything except memory.
-Power draw should be less than S0ix in theory, but the actual difference on the
-MiniBook X needs testing.
+
+**Recommended.** On the MiniBook X, S0ix does not reach its low-power
+residency states reliably and drains the battery noticeably overnight. S3
+("deep") suspends to a true low-power state and, in testing on this device,
+gives substantially better standby battery life. Switch to `deep` and make it
+the default unless you have a specific reason to keep s2idle.
 
 ### Switching between modes
 
-To switch to S3 (hardware sleep):
+To switch to S3 (hardware sleep, recommended):
 
 ```
 echo deep | sudo tee /sys/power/mem_sleep
@@ -390,7 +394,7 @@ To switch to S0ix (software sleep):
 echo s2idle | sudo tee /sys/power/mem_sleep
 ```
 
-These changes do not persist across reboots. To make the setting permanent, add
-`mem_sleep_default=deep` or `mem_sleep_default=s2idle` to the kernel command
-line in `/etc/default/limine` and rebuild the initramfs with
-`sudo limine-mkinitcpio`.
+These changes do not persist across reboots. To make `deep` the default
+permanently, add `mem_sleep_default=deep` to the kernel command line in
+`/etc/default/limine` and rebuild the initramfs with `sudo limine-mkinitcpio`
+(use `mem_sleep_default=s2idle` if you ever need to go back).

--- a/docs/iio-sensor-proxy.md
+++ b/docs/iio-sensor-proxy.md
@@ -27,6 +27,41 @@ The fork source lives in `iio-sensor-proxy/`.
 
 See [GUIDE.md](../GUIDE.md#7-iio-sensor-proxy).
 
+## Lazy polling (`--lazy`)
+
+By default the proxy polls both accelerometers continuously (every 50 ms) for
+as long as it runs, so that tablet-mode transitions are detected even when no
+desktop client is listening. This keeps the I2C bus and the sensors active the
+whole time the daemon is up.
+
+The `--lazy` flag makes the proxy poll a sensor only while a D-Bus client has
+explicitly claimed it (via `ClaimAccelerometer` / `ClaimLight`), and stops
+polling again once the last client releases it. This saves power when nothing
+is consuming orientation events, at the cost of tablet-mode detection being
+inactive until a client claims the accelerometer.
+
+To enable it, add the flag to the service's `ExecStart`:
+
+```
+sudo systemctl edit iio-sensor-proxy
+```
+
+```
+[Service]
+ExecStart=
+ExecStart=/usr/lib/iio-sensor-proxy --lazy
+```
+
+Then `sudo systemctl restart iio-sensor-proxy`. The path varies by distro
+(`/usr/lib` on Arch, `/usr/libexec` elsewhere); `systemctl cat
+iio-sensor-proxy` shows the current `ExecStart` to copy.
+
+## Lid gating
+
+Polling stops while the lid is closed (regardless of `--lazy` or any claim) and
+resumes when it opens; tablet mode is unaffected. The driver logs each
+transition to the journal: `journalctl -u iio-sensor-proxy | grep 'polling'`.
+
 ## Runtime requirement
 
 The `acpi_call` kernel module must be loaded for tablet mode transitions (the

--- a/iio-sensor-proxy/packaging/arch/.gitignore
+++ b/iio-sensor-proxy/packaging/arch/.gitignore
@@ -1,0 +1,4 @@
+pkg/
+src/
+*.pkg.tar.zst
+*.pkg.tar.xz

--- a/iio-sensor-proxy/src/drv-mxc6655-accel.c
+++ b/iio-sensor-proxy/src/drv-mxc6655-accel.c
@@ -30,6 +30,8 @@
 #define ACPI_MATCH_ID		"MDA6655"
 #define I2C_UNBIND_DRIVER	"mxc4005"
 #define MAX_I2C_BUS		20
+#define MAX_INPUT_DEV		32
+#define LID_SWITCH_NAME		"Lid Switch"
 #define UINPUT_DEV_NAME		"MXC6655 Tablet Mode Control"
 
 /* GMTR PARB thresholds from DSDT \_SB.ACMK.GMTR */
@@ -113,6 +115,10 @@ typedef struct {
 
 typedef struct {
 	guint              timeout_id;
+	gboolean           want_polling;
+	gboolean           lid_closed;
+	gint               lid_fd;
+	guint              lid_watch_id;
 	gint               i2c_fds[2];
 	gint               uinput_fd;
 	gint               ltsm_warned;
@@ -1147,6 +1153,8 @@ mxc6655_discover (GUdevDevice *device)
 	return TRUE;
 }
 
+static void setup_lid_watch (SensorDevice *sensor_device);
+
 static SensorDevice *
 mxc6655_open (GUdevDevice *device)
 {
@@ -1161,6 +1169,7 @@ mxc6655_open (GUdevDevice *device)
 	drv_data->i2c_fds[0] = -1;
 	drv_data->i2c_fds[1] = -1;
 	drv_data->uinput_fd = -1;
+	drv_data->lid_fd = -1;
 	drv_data->mode = -1;
 	drv_data->cur_orient = -1;
 	drv_data->pending_orient = -1;
@@ -1207,7 +1216,165 @@ mxc6655_open (GUdevDevice *device)
 	sensor_device->name = g_strdup ("MXC6655 dual-accel");
 	sensor_device->priv = drv_data;
 
+	setup_lid_watch (sensor_device);
+
 	return sensor_device;
+}
+
+static void
+send_initial_reading (SensorDevice *sensor_device)
+{
+	AccelReadings readings;
+
+	build_synthetic_readings (MXC_ORIENT_RIGHT, &readings);
+	sensor_device->callback_func (sensor_device,
+				      (gpointer) &readings,
+				      sensor_device->user_data);
+}
+
+static gboolean
+polling_wanted (DrvData *drv_data)
+{
+	return drv_data->want_polling && !drv_data->lid_closed;
+}
+
+static void
+start_poll_timer (SensorDevice *sensor_device)
+{
+	DrvData *drv_data = (DrvData *) sensor_device->priv;
+
+	drv_data->timeout_id = g_timeout_add (GMTR_POLL_MS, poll_sensors, sensor_device);
+	g_source_set_name_by_id (drv_data->timeout_id, "[mxc6655] poll_sensors");
+	g_message ("MXC6655 dual-accel: polling active");
+}
+
+static void
+stop_poll_timer (SensorDevice *sensor_device)
+{
+	DrvData *drv_data = (DrvData *) sensor_device->priv;
+	const char *reason;
+
+	g_source_remove (drv_data->timeout_id);
+	drv_data->timeout_id = 0;
+
+	if (drv_data->lid_closed)
+		reason = "lid closed";
+	else
+		reason = "no client";
+	g_message ("MXC6655 dual-accel: polling idle (%s)", reason);
+}
+
+static void
+update_polling_timer (SensorDevice *sensor_device)
+{
+	DrvData *drv_data = (DrvData *) sensor_device->priv;
+	gboolean wanted = polling_wanted (drv_data);
+
+	if (wanted && drv_data->timeout_id == 0)
+		start_poll_timer (sensor_device);
+	else if (!wanted && drv_data->timeout_id > 0)
+		stop_poll_timer (sensor_device);
+}
+
+static gint
+open_lid_switch (void)
+{
+	for (gint i = 0; i < MAX_INPUT_DEV; i++) {
+		char path[64];
+		char name[256] = { 0 };
+		gint fd;
+
+		g_snprintf (path, sizeof (path), "/dev/input/event%d", i);
+		fd = open (path, O_RDONLY | O_NONBLOCK | O_CLOEXEC);
+		if (fd < 0)
+			continue;
+
+		if (ioctl (fd, EVIOCGNAME (sizeof (name)), name) >= 0 &&
+		    strcmp (name, LID_SWITCH_NAME) == 0)
+			return fd;
+
+		close (fd);
+	}
+
+	return -1;
+}
+
+static gboolean
+read_lid_closed (gint fd)
+{
+	unsigned long bits = 0;
+
+	if (ioctl (fd, EVIOCGSW (sizeof (bits)), &bits) < 0)
+		return FALSE;
+
+	return (bits & (1UL << SW_LID)) != 0;
+}
+
+static void
+set_lid_closed (SensorDevice *sensor_device,
+		gboolean      closed)
+{
+	DrvData *drv_data = (DrvData *) sensor_device->priv;
+
+	if (drv_data->lid_closed == closed)
+		return;
+
+	drv_data->lid_closed = closed;
+	update_polling_timer (sensor_device);
+}
+
+static gboolean
+lid_event_cb (GIOChannel   *channel,
+	      GIOCondition  condition,
+	      gpointer      user_data)
+{
+	SensorDevice *sensor_device = user_data;
+	DrvData *drv_data = (DrvData *) sensor_device->priv;
+	struct input_event ev;
+
+	if (condition & (G_IO_HUP | G_IO_ERR)) {
+		drv_data->lid_watch_id = 0;
+		return G_SOURCE_REMOVE;
+	}
+
+	while (TRUE) {
+		gsize bytes_read;
+		GIOStatus status;
+
+		status = g_io_channel_read_chars (channel, (gchar *) &ev,
+						  sizeof (ev), &bytes_read, NULL);
+		if (status != G_IO_STATUS_NORMAL || bytes_read != sizeof (ev))
+			break;
+		if (ev.type != EV_SW || ev.code != SW_LID)
+			continue;
+
+		set_lid_closed (sensor_device, ev.value != 0);
+	}
+
+	return G_SOURCE_CONTINUE;
+}
+
+static void
+setup_lid_watch (SensorDevice *sensor_device)
+{
+	DrvData *drv_data = (DrvData *) sensor_device->priv;
+	GIOChannel *channel;
+
+	drv_data->lid_fd = open_lid_switch ();
+	if (drv_data->lid_fd < 0) {
+		g_debug ("No lid switch found, polling not lid-gated");
+		return;
+	}
+
+	drv_data->lid_closed = read_lid_closed (drv_data->lid_fd);
+
+	channel = g_io_channel_unix_new (drv_data->lid_fd);
+	g_io_channel_set_encoding (channel, NULL, NULL);
+	g_io_channel_set_buffered (channel, FALSE);
+	drv_data->lid_watch_id = g_io_add_watch (channel,
+						 G_IO_IN | G_IO_HUP | G_IO_ERR,
+						 lid_event_cb, sensor_device);
+	g_io_channel_unref (channel);
 }
 
 static void
@@ -1216,36 +1383,27 @@ mxc6655_set_polling (SensorDevice *sensor_device,
 {
 	DrvData *drv_data = (DrvData *) sensor_device->priv;
 
-	if (drv_data->timeout_id > 0 && state)
+	if (drv_data->want_polling == state)
 		return;
-	if (drv_data->timeout_id == 0 && !state)
-		return;
+	drv_data->want_polling = state;
 
-	if (drv_data->timeout_id) {
-		g_source_remove (drv_data->timeout_id);
-		drv_data->timeout_id = 0;
-	}
+	/* Send a first reading so a client's Claim() returns even if the lid is
+	 * closed and the poll timer stays stopped. */
+	if (state)
+		send_initial_reading (sensor_device);
 
-	if (state) {
-		drv_data->timeout_id = g_timeout_add (GMTR_POLL_MS, poll_sensors, sensor_device);
-		g_source_set_name_by_id (drv_data->timeout_id, "[mxc6655_set_polling] poll_sensors");
-
-		/* Send initial orientation reading */
-		{
-			AccelReadings readings;
-
-			build_synthetic_readings (MXC_ORIENT_RIGHT, &readings);
-			sensor_device->callback_func (sensor_device,
-						      (gpointer) &readings,
-						      sensor_device->user_data);
-		}
-	}
+	update_polling_timer (sensor_device);
 }
 
 static void
 mxc6655_close (SensorDevice *sensor_device)
 {
 	DrvData *drv_data = (DrvData *) sensor_device->priv;
+
+	if (drv_data->lid_watch_id > 0)
+		g_source_remove (drv_data->lid_watch_id);
+	if (drv_data->lid_fd >= 0)
+		close (drv_data->lid_fd);
 
 	if (drv_data->uinput_fd >= 0) {
 		ioctl (drv_data->uinput_fd, UI_DEV_DESTROY);

--- a/iio-sensor-proxy/src/iio-sensor-proxy.c
+++ b/iio-sensor-proxy/src/iio-sensor-proxy.c
@@ -41,6 +41,7 @@ typedef struct {
 	GDBusConnection *connection;
 	guint name_id;
 	int ret;
+	gboolean lazy;
 
 	PolkitAuthority *auth;
 
@@ -426,7 +427,8 @@ client_release (SensorData            *data,
 
 	g_hash_table_remove (ht, sender);
 
-	if (driver_type_exists (data, driver_type) &&
+	if (data->lazy &&
+	    driver_type_exists (data, driver_type) &&
 	    g_hash_table_size (ht) == 0) {
 		SensorDevice *sensor_device = DEVICE_FOR_TYPE(driver_type);
 		driver_set_polling (sensor_device, FALSE);
@@ -782,6 +784,9 @@ name_acquired_handler (GDBusConnection *connection,
 		}
 
 		DEVICE_FOR_TYPE(i) = sensor_device;
+
+		if (!data->lazy)
+			driver_set_polling (sensor_device, TRUE);
 	}
 
 	if (!any_sensors_left (data))
@@ -1117,6 +1122,8 @@ sensor_changes (GUdevClient *client,
 						driver_set_polling (sensor_device, TRUE);
 					} else {
 						send_driver_changed_dbus_event (data, driver->type);
+						if (!data->lazy)
+							driver_set_polling (sensor_device, TRUE);
 					}
 				}
 				break;
@@ -1143,9 +1150,11 @@ int main (int argc, char **argv)
 	g_autoptr(GError) error = NULL;
 	gboolean verbose = FALSE;
 	gboolean replace = FALSE;
+	gboolean lazy = FALSE;
 	const GOptionEntry options[] = {
 		{ "verbose", 'v', 0, G_OPTION_ARG_NONE, &verbose, "Show extra debugging information", NULL },
 		{ "replace", 'r', 0, G_OPTION_ARG_NONE, &replace, "Replace the running instance of iio-sensor-proxy", NULL },
+		{ "lazy", 0, 0, G_OPTION_ARG_NONE, &lazy, "Only poll sensors while a D-Bus client has claimed them", NULL },
 		{ NULL}
 	};
 	int ret = 0;
@@ -1172,6 +1181,7 @@ int main (int argc, char **argv)
 	data->previous_orientation = ORIENTATION_UNDEFINED;
 	data->previous_tilt = TILT_UNDEFINED;
 	data->uses_lux = TRUE;
+	data->lazy = lazy;
 
 	/* Set up D-Bus */
 	setup_dbus (data, replace);

--- a/thermal_daemon/packaging/arch/PKGBUILD
+++ b/thermal_daemon/packaging/arch/PKGBUILD
@@ -15,8 +15,10 @@ source=()
 _source_root="${startdir}/../.."
 
 pkgver() {
-  awk -F"'" '/^PACKAGE_VERSION=/ {print $2; exit}' \
-    "${_source_root}/configure"
+  local major minor
+  major="$(awk -F'[][]' '/^m4_define\(\[td_major_version\]/ {print $4}' "${_source_root}/configure.ac")"
+  minor="$(awk -F'[][]' '/^m4_define\(\[td_minor_version\]/ {print $4}' "${_source_root}/configure.ac")"
+  echo "${major}.${minor}"
 }
 
 _clean_stale_autotools_artifacts() {
@@ -33,7 +35,9 @@ _bootstrap_if_needed() {
 
 prepare() {
   rm -rf "${srcdir}/src"
-  cp -a "${_source_root}" "${srcdir}/src"
+  mkdir -p "${srcdir}/src"
+  tar -C "${_source_root}" --exclude='./packaging' -cf - . | \
+    tar -C "${srcdir}/src" -xf -
   cd "${srcdir}/src"
   _clean_stale_autotools_artifacts
 }

--- a/tools/check-status.sh
+++ b/tools/check-status.sh
@@ -440,6 +440,25 @@ read_iio_version() {
   echo "NOT FOUND"
 }
 
+read_iio_polling_line() {
+  journalctl -u iio-sensor-proxy --no-pager 2>/dev/null \
+    | grep -E 'MXC6655 dual-accel: polling (active|idle)' \
+    | tail -1 || true
+}
+
+check_iio_polling() {
+  local line
+  line="$(read_iio_polling_line)"
+  if [[ -z "${line}" ]]; then
+    return
+  fi
+  if [[ "${line}" == *"polling active"* ]]; then
+    print_detail "sensor polling active (client claimed)"
+  else
+    print_detail "sensor polling idle${line#*polling idle}"
+  fi
+}
+
 check_services() {
   echo ""
   echo "--- services ---"
@@ -451,6 +470,7 @@ check_services() {
 
   iio_ver="$(read_iio_version)"
   check_service "iio-sensor-proxy" "${iio_ver}"
+  check_iio_polling
 }
 
 print_warnings() {


### PR DESCRIPTION
- `--lazy` option to disable that (old behaviour)
- stronger recommendation for deep sleep now that I've tested it
- some minor build tweaks
- don't monitor accelerometers when lid is closed