### PR TITLE
iio-sensor-proxy: add libdrm to Arch package deps

### DIFF
--- a/iio-sensor-proxy/packaging/arch/PKGBUILD
+++ b/iio-sensor-proxy/packaging/arch/PKGBUILD
@@ -2,12 +2,12 @@
 
 pkgname=iio-sensor-proxy
 pkgver=3.9.minibook1
-pkgrel=1
+pkgrel=2
 pkgdesc='IIO accelerometer sensor to input device proxy (Chuwi MiniBook X build)'
 arch=('x86_64')
 url='https://github.com/fstanis/chuwi-minibook'
 license=('GPL-3.0-only')
-depends=('glib2' 'glibc' 'libgcc' 'libgudev' 'libssc' 'polkit')
+depends=('glib2' 'glibc' 'libdrm' 'libgcc' 'libgudev' 'libssc' 'polkit')
 makedepends=('meson' 'ninja' 'gtk-doc' 'docbook-xsl')
 source=()
 


### PR DESCRIPTION
Since #13 the proxy reads the DRM `panel orientation` property of the DSI connector, and `meson.build` gained a `dependency('libdrm')`. The PKGBUILD was never updated to match, so `makepkg` in `iio-sensor-proxy/packaging/arch` fails at configure time on a machine that does not already have libdrm installed:

```
ERROR: Dependency "libdrm" not found, tried pkgconfig and cmake
```

This adds `libdrm` to `depends` and bumps `pkgrel` so existing installs pick up the rebuilt package.

### Verification

```
$ meson setup build . && meson compile -C build
Run-time dependency libdrm found: YES 2.4.134
[36/36] Linking target src/iio-sensor-proxy
```
