### PR TITLE
packaging: add Arch PKGBUILDs for the four DKMS modules

### DIFF
--- a/modules/dptf_enabler/packaging/arch/.gitignore
+++ b/modules/dptf_enabler/packaging/arch/.gitignore
@@ -1,0 +1,4 @@
+pkg/
+src/
+*.pkg.tar.zst
+*.pkg.tar.xz

--- a/modules/dptf_enabler/packaging/arch/PKGBUILD
+++ b/modules/dptf_enabler/packaging/arch/PKGBUILD
@@ -1,0 +1,22 @@
+# Maintainer: Grigorii Horos <horosgrisa@gmail.com>
+
+pkgname=dptf_enabler-dkms
+pkgver=1.0
+pkgrel=1
+pkgdesc='ACPI DPTF device enabler for Chuwi MiniBook X (DKMS)'
+arch=('any')
+url='https://github.com/fstanis/chuwi-minibook'
+license=('GPL-2.0-only')
+depends=('dkms')
+source=()
+
+_source_root="${startdir}/../.."
+_module=dptf_enabler
+
+package() {
+  local destdir="${pkgdir}/usr/src/${_module}-${pkgver}"
+  install -dm755 "${destdir}"
+  cp "${_source_root}/Kbuild" "${_source_root}/dkms.conf" \
+     "${_source_root}/dptf_enabler.c" \
+     "${destdir}/"
+}

--- a/modules/goodix_ts/packaging/arch/.gitignore
+++ b/modules/goodix_ts/packaging/arch/.gitignore
@@ -1,0 +1,4 @@
+pkg/
+src/
+*.pkg.tar.zst
+*.pkg.tar.xz

--- a/modules/goodix_ts/packaging/arch/PKGBUILD
+++ b/modules/goodix_ts/packaging/arch/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: Grigorii Horos <horosgrisa@gmail.com>
+
+pkgname=goodix_ts-dkms
+pkgver=7.2.0.minibook1  # updated by pkgver()
+pkgrel=1
+pkgdesc='Goodix touchscreen driver for Chuwi MiniBook X with resume fix (DKMS)'
+arch=('any')
+url='https://github.com/fstanis/chuwi-minibook'
+license=('GPL-2.0-only')
+depends=('dkms')
+makedepends=('curl')
+source=()
+
+_source_root="${startdir}/../.."
+_module=goodix_ts
+
+pkgver() {
+  local kver
+  kver="$(uname -r | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')"
+  echo "${kver}.minibook1"
+}
+
+prepare() {
+  rm -rf "${srcdir}/build"
+  mkdir -p "${srcdir}/build"
+  cp "${_source_root}/Kbuild" \
+     "${_source_root}/dkms.conf" \
+     "${_source_root}/goodix_resume.patch" \
+     "${_source_root}/goodix_cfg.bin" \
+     "${srcdir}/build/"
+  cd "${srcdir}/build"
+  local kver_mm
+  kver_mm="$(uname -r | grep -oE '^[0-9]+\.[0-9]+')"
+  local base='https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain'
+  local dir='drivers/input/touchscreen'
+  for f in goodix.c goodix.h goodix_fwupload.c; do
+    curl -fsSL -o "${f}" "${base}/${dir}/${f}?h=linux-${kver_mm}.y"
+  done
+  patch -p1 < goodix_resume.patch
+}
+
+package() {
+  local ver
+  ver="$(pkgver)"
+  local destdir="${pkgdir}/usr/src/${_module}-${ver}"
+  install -dm755 "${destdir}"
+  cd "${srcdir}/build"
+  cp Kbuild dkms.conf goodix.c goodix.h goodix_fwupload.c "${destdir}/"
+  sed -i "s/^PACKAGE_VERSION=.*/PACKAGE_VERSION=\"${ver}\"/" "${destdir}/dkms.conf"
+  install -Dm644 goodix_cfg.bin "${pkgdir}/usr/lib/firmware/goodix_9110_cfg.bin"
+}

--- a/modules/i2c_designware_spklen/packaging/arch/.gitignore
+++ b/modules/i2c_designware_spklen/packaging/arch/.gitignore
@@ -1,0 +1,4 @@
+pkg/
+src/
+*.pkg.tar.zst
+*.pkg.tar.xz

--- a/modules/i2c_designware_spklen/packaging/arch/PKGBUILD
+++ b/modules/i2c_designware_spklen/packaging/arch/PKGBUILD
@@ -1,0 +1,22 @@
+# Maintainer: Grigorii Horos <horosgrisa@gmail.com>
+
+pkgname=i2c_designware_spklen-dkms
+pkgver=1.0
+pkgrel=1
+pkgdesc='I2C DesignWare spike suppression for Intel LPSS controllers on Chuwi MiniBook X (DKMS)'
+arch=('any')
+url='https://github.com/fstanis/chuwi-minibook'
+license=('GPL-2.0-only')
+depends=('dkms')
+source=()
+
+_source_root="${startdir}/../.."
+_module=i2c_designware_spklen
+
+package() {
+  local destdir="${pkgdir}/usr/src/${_module}-${pkgver}"
+  install -dm755 "${destdir}"
+  cp "${_source_root}/Kbuild" "${_source_root}/dkms.conf" \
+     "${_source_root}/i2c_designware_spklen.c" \
+     "${destdir}/"
+}

--- a/modules/minibook_ec/packaging/arch/.gitignore
+++ b/modules/minibook_ec/packaging/arch/.gitignore
@@ -1,0 +1,4 @@
+pkg/
+src/
+*.pkg.tar.zst
+*.pkg.tar.xz

--- a/modules/minibook_ec/packaging/arch/PKGBUILD
+++ b/modules/minibook_ec/packaging/arch/PKGBUILD
@@ -1,0 +1,22 @@
+# Maintainer: Grigorii Horos <horosgrisa@gmail.com>
+
+pkgname=minibook_ec-dkms
+pkgver=1.0
+pkgrel=1
+pkgdesc='EC platform driver for Chuwi MiniBook X (thermal, keyboard backlight, DKMS)'
+arch=('any')
+url='https://github.com/fstanis/chuwi-minibook'
+license=('GPL-2.0-only')
+depends=('dkms')
+source=()
+
+_source_root="${startdir}/../.."
+_module=minibook_ec
+
+package() {
+  local destdir="${pkgdir}/usr/src/${_module}-${pkgver}"
+  install -dm755 "${destdir}"
+  cp "${_source_root}/Kbuild" "${_source_root}/dkms.conf" \
+     "${_source_root}"/*.c "${_source_root}"/*.h \
+     "${destdir}/"
+}

--- a/thermal_daemon/packaging/arch/.gitignore
+++ b/thermal_daemon/packaging/arch/.gitignore
@@ -1,0 +1,3 @@
+src/
+*.pkg.tar.zst
+*.pkg.tar.xz


### PR DESCRIPTION
`thermal_daemon` and `iio-sensor-proxy` already ship a PKGBUILD, but the kernel modules can only be installed with `sudo make install`, which writes straight into `/usr/src` and leaves nothing for the package manager to track. On Arch that means a DKMS tree the system does not know about: `pacman -Qo` finds nothing, uninstalling means remembering the exact `dkms remove` invocation, and a botched build has to be cleaned up by hand.

This adds a PKGBUILD for each of the four modules, following the layout the two existing packages already use — `_source_root="${startdir}/../.."`, empty `source=()`, building straight from the checkout:

| package | notes |
| --- | --- |
| `goodix_ts-dkms` | downloads the upstream touchscreen sources for the running kernel in `prepare()`, applies `goodix_resume.patch`, ships `goodix_cfg.bin` to `/usr/lib/firmware` |
| `minibook_ec-dkms` | |
| `dptf_enabler-dkms` | |
| `i2c_designware_spklen-dkms` | |

Each package installs the module sources to `/usr/src/<name>-<version>` and lets the dkms pacman hook do the add/build/install, so the module is rebuilt automatically on a kernel upgrade and removed cleanly on `pacman -R`.

`goodix_ts-dkms` derives its version from the running kernel in `pkgver()`, matching the `DKMS_VERSION` the Makefile computes, because the driver is patched against the kernel's own copy of the source.

Also adds a `.gitignore` to each `packaging/arch` directory — and to `thermal_daemon`'s, which was missing one — so makepkg's `pkg/`, `src/` and built `.pkg.tar.zst` artifacts stay out of git.

### Verification

`bash -n` and `makepkg --printsrcinfo` on all four, plus a full `makepkg -f` for `minibook_ec-dkms`:

```
==> Finished making: minibook_ec-dkms 1.0-1
$ bsdtar tf minibook_ec-dkms-1.0-1-any.pkg.tar.zst
usr/src/minibook_ec-1.0/Kbuild
usr/src/minibook_ec-1.0/dkms.conf
usr/src/minibook_ec-1.0/minibook_ec.h
usr/src/minibook_ec-1.0/minibook_ec_core.c
...
```

Two small follow-ups build on this one, kept separate to keep each diff readable: a `make install-arch` target and a `modules-load.d` config per module.
