### PR TITLE
modules: add an install-arch make target

### DIFF
--- a/modules/dptf_enabler/Makefile
+++ b/modules/dptf_enabler/Makefile
@@ -28,6 +28,12 @@ compile_commands.json:
 	/lib/modules/$(shell uname -r)/build/scripts/clang-tools/gen_compile_commands.py \
 		-d $(CURDIR) -o compile_commands.json
 
+install-arch:
+	cd packaging/arch && makepkg -f
+	-sudo dkms remove -m "$(DKMS_NAME)" -v "$(DKMS_VERSION)" --all 2>/dev/null
+	-sudo rm -rf "$(DKMS_DIR)"
+	sudo pacman -U --noconfirm packaging/arch/$(DKMS_NAME)-dkms-$(DKMS_VERSION)-*.pkg.tar.zst
+
 enable:
 	modprobe "$(DKMS_NAME)"
 	echo "$(DKMS_NAME)" > /etc/modules-load.d/$(DKMS_NAME).conf
@@ -36,4 +42,4 @@ disable:
 	rm -f /etc/modules-load.d/$(DKMS_NAME).conf
 	modprobe -r "$(DKMS_NAME)" 2>/dev/null || true
 
-.PHONY: all install uninstall clean enable disable compile_commands.json
+.PHONY: all install install-arch uninstall clean enable disable compile_commands.json

--- a/modules/dptf_enabler/packaging/arch/.gitignore
+++ b/modules/dptf_enabler/packaging/arch/.gitignore
@@ -1,0 +1,4 @@
+pkg/
+src/
+*.pkg.tar.zst
+*.pkg.tar.xz

--- a/modules/dptf_enabler/packaging/arch/PKGBUILD
+++ b/modules/dptf_enabler/packaging/arch/PKGBUILD
@@ -1,0 +1,22 @@
+# Maintainer: Grigorii Horos <horosgrisa@gmail.com>
+
+pkgname=dptf_enabler-dkms
+pkgver=1.0
+pkgrel=1
+pkgdesc='ACPI DPTF device enabler for Chuwi MiniBook X (DKMS)'
+arch=('any')
+url='https://github.com/fstanis/chuwi-minibook'
+license=('GPL-2.0-only')
+depends=('dkms')
+source=()
+
+_source_root="${startdir}/../.."
+_module=dptf_enabler
+
+package() {
+  local destdir="${pkgdir}/usr/src/${_module}-${pkgver}"
+  install -dm755 "${destdir}"
+  cp "${_source_root}/Kbuild" "${_source_root}/dkms.conf" \
+     "${_source_root}/dptf_enabler.c" \
+     "${destdir}/"
+}

--- a/modules/goodix_ts/packaging/arch/.gitignore
+++ b/modules/goodix_ts/packaging/arch/.gitignore
@@ -1,0 +1,4 @@
+pkg/
+src/
+*.pkg.tar.zst
+*.pkg.tar.xz

--- a/modules/goodix_ts/packaging/arch/PKGBUILD
+++ b/modules/goodix_ts/packaging/arch/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: Grigorii Horos <horosgrisa@gmail.com>
+
+pkgname=goodix_ts-dkms
+pkgver=7.2.0.minibook1  # updated by pkgver()
+pkgrel=1
+pkgdesc='Goodix touchscreen driver for Chuwi MiniBook X with resume fix (DKMS)'
+arch=('any')
+url='https://github.com/fstanis/chuwi-minibook'
+license=('GPL-2.0-only')
+depends=('dkms')
+makedepends=('curl')
+source=()
+
+_source_root="${startdir}/../.."
+_module=goodix_ts
+
+pkgver() {
+  local kver
+  kver="$(uname -r | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')"
+  echo "${kver}.minibook1"
+}
+
+prepare() {
+  rm -rf "${srcdir}/build"
+  mkdir -p "${srcdir}/build"
+  cp "${_source_root}/Kbuild" \
+     "${_source_root}/dkms.conf" \
+     "${_source_root}/goodix_resume.patch" \
+     "${_source_root}/goodix_cfg.bin" \
+     "${srcdir}/build/"
+  cd "${srcdir}/build"
+  local kver_mm
+  kver_mm="$(uname -r | grep -oE '^[0-9]+\.[0-9]+')"
+  local base='https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain'
+  local dir='drivers/input/touchscreen'
+  for f in goodix.c goodix.h goodix_fwupload.c; do
+    curl -fsSL -o "${f}" "${base}/${dir}/${f}?h=linux-${kver_mm}.y"
+  done
+  patch -p1 < goodix_resume.patch
+}
+
+package() {
+  local ver
+  ver="$(pkgver)"
+  local destdir="${pkgdir}/usr/src/${_module}-${ver}"
+  install -dm755 "${destdir}"
+  cd "${srcdir}/build"
+  cp Kbuild dkms.conf goodix.c goodix.h goodix_fwupload.c "${destdir}/"
+  sed -i "s/^PACKAGE_VERSION=.*/PACKAGE_VERSION=\"${ver}\"/" "${destdir}/dkms.conf"
+  install -Dm644 goodix_cfg.bin "${pkgdir}/usr/lib/firmware/goodix_9110_cfg.bin"
+}

--- a/modules/i2c_designware_spklen/Makefile
+++ b/modules/i2c_designware_spklen/Makefile
@@ -28,6 +28,12 @@ compile_commands.json:
 	/lib/modules/$(shell uname -r)/build/scripts/clang-tools/gen_compile_commands.py \
 		-d $(CURDIR) -o compile_commands.json
 
+install-arch:
+	cd packaging/arch && makepkg -f
+	-sudo dkms remove -m "$(DKMS_NAME)" -v "$(DKMS_VERSION)" --all 2>/dev/null
+	-sudo rm -rf "$(DKMS_DIR)"
+	sudo pacman -U --noconfirm packaging/arch/$(DKMS_NAME)-dkms-$(DKMS_VERSION)-*.pkg.tar.zst
+
 enable:
 	modprobe "$(DKMS_NAME)"
 	echo "$(DKMS_NAME)" > /etc/modules-load.d/$(DKMS_NAME).conf
@@ -36,4 +42,4 @@ disable:
 	rm -f /etc/modules-load.d/$(DKMS_NAME).conf
 	modprobe -r "$(DKMS_NAME)" 2>/dev/null || true
 
-.PHONY: all install uninstall clean enable disable compile_commands.json
+.PHONY: all install install-arch uninstall clean enable disable compile_commands.json

--- a/modules/i2c_designware_spklen/packaging/arch/.gitignore
+++ b/modules/i2c_designware_spklen/packaging/arch/.gitignore
@@ -1,0 +1,4 @@
+pkg/
+src/
+*.pkg.tar.zst
+*.pkg.tar.xz

--- a/modules/i2c_designware_spklen/packaging/arch/PKGBUILD
+++ b/modules/i2c_designware_spklen/packaging/arch/PKGBUILD
@@ -1,0 +1,22 @@
+# Maintainer: Grigorii Horos <horosgrisa@gmail.com>
+
+pkgname=i2c_designware_spklen-dkms
+pkgver=1.0
+pkgrel=1
+pkgdesc='I2C DesignWare spike suppression for Intel LPSS controllers on Chuwi MiniBook X (DKMS)'
+arch=('any')
+url='https://github.com/fstanis/chuwi-minibook'
+license=('GPL-2.0-only')
+depends=('dkms')
+source=()
+
+_source_root="${startdir}/../.."
+_module=i2c_designware_spklen
+
+package() {
+  local destdir="${pkgdir}/usr/src/${_module}-${pkgver}"
+  install -dm755 "${destdir}"
+  cp "${_source_root}/Kbuild" "${_source_root}/dkms.conf" \
+     "${_source_root}/i2c_designware_spklen.c" \
+     "${destdir}/"
+}

--- a/modules/minibook_ec/Makefile
+++ b/modules/minibook_ec/Makefile
@@ -32,6 +32,12 @@ compile_commands.json:
 	/lib/modules/$(shell uname -r)/build/scripts/clang-tools/gen_compile_commands.py \
 		-d $(CURDIR) -o compile_commands.json
 
+install-arch:
+	cd packaging/arch && makepkg -f
+	-sudo dkms remove -m "$(DKMS_NAME)" -v "$(DKMS_VERSION)" --all 2>/dev/null
+	-sudo rm -rf "$(DKMS_DIR)"
+	sudo pacman -U --noconfirm packaging/arch/$(DKMS_NAME)-dkms-$(DKMS_VERSION)-*.pkg.tar.zst
+
 enable:
 	modprobe "$(DKMS_NAME)"
 	echo "$(DKMS_NAME)" > /etc/modules-load.d/$(DKMS_NAME).conf
@@ -40,4 +46,4 @@ disable:
 	rm -f /etc/modules-load.d/$(DKMS_NAME).conf
 	modprobe -r "$(DKMS_NAME)" 2>/dev/null || true
 
-.PHONY: all install uninstall clean enable disable compile_commands.json
+.PHONY: all install install-arch uninstall clean enable disable compile_commands.json

--- a/modules/minibook_ec/packaging/arch/.gitignore
+++ b/modules/minibook_ec/packaging/arch/.gitignore
@@ -1,0 +1,4 @@
+pkg/
+src/
+*.pkg.tar.zst
+*.pkg.tar.xz

--- a/modules/minibook_ec/packaging/arch/PKGBUILD
+++ b/modules/minibook_ec/packaging/arch/PKGBUILD
@@ -1,0 +1,22 @@
+# Maintainer: Grigorii Horos <horosgrisa@gmail.com>
+
+pkgname=minibook_ec-dkms
+pkgver=1.0
+pkgrel=1
+pkgdesc='EC platform driver for Chuwi MiniBook X (thermal, keyboard backlight, DKMS)'
+arch=('any')
+url='https://github.com/fstanis/chuwi-minibook'
+license=('GPL-2.0-only')
+depends=('dkms')
+source=()
+
+_source_root="${startdir}/../.."
+_module=minibook_ec
+
+package() {
+  local destdir="${pkgdir}/usr/src/${_module}-${pkgver}"
+  install -dm755 "${destdir}"
+  cp "${_source_root}/Kbuild" "${_source_root}/dkms.conf" \
+     "${_source_root}"/*.c "${_source_root}"/*.h \
+     "${destdir}/"
+}

--- a/thermal_daemon/packaging/arch/.gitignore
+++ b/thermal_daemon/packaging/arch/.gitignore
@@ -1,0 +1,3 @@
+src/
+*.pkg.tar.zst
+*.pkg.tar.xz


### PR DESCRIPTION
> **Stacked on #15** — that PR adds the PKGBUILDs this target invokes, so the diff here also shows its commit. Only `ebf4873` belongs to this PR; the diff collapses to three Makefiles once #15 lands.

With a PKGBUILD in place there are two ways to install a module, and they do not coexist: `make install` writes an untracked DKMS tree into `/usr/src`, and a later `pacman -U` of the same module hits a file conflict with it.

This adds `make install-arch` to `minibook_ec`, `dptf_enabler` and `i2c_designware_spklen`. It builds the package, tears down any DKMS tree left behind by a previous `make install`, and installs through pacman:

```make
install-arch:
	cd packaging/arch && makepkg -f
	-sudo dkms remove -m "$(DKMS_NAME)" -v "$(DKMS_VERSION)" --all 2>/dev/null
	-sudo rm -rf "$(DKMS_DIR)"
	sudo pacman -U --noconfirm packaging/arch/$(DKMS_NAME)-dkms-$(DKMS_VERSION)-*.pkg.tar.zst
```

The `dkms remove` and `rm` are prefixed with `-` so a clean machine, where there is nothing to tear down, does not fail the target.

### Why goodix_ts is left out

Its `DKMS_VERSION` is `$(KVER)-minibook1` while `pkgver()` produces `${kver}.minibook1` — pacman does not allow a dash in `pkgver` — so the glob above would never match the built file. Its package is built with `cd packaging/arch && makepkg -si` until the two version strings are reconciled. Happy to add the target there too if you would rather see the naming unified.
