### PR TITLE
modules: ship a modules-load.d config with each module

### DIFF
--- a/modules/dptf_enabler/dptf_enabler.conf
+++ b/modules/dptf_enabler/dptf_enabler.conf
@@ -1,0 +1,1 @@
+dptf_enabler

--- a/modules/dptf_enabler/packaging/arch/PKGBUILD
+++ b/modules/dptf_enabler/packaging/arch/PKGBUILD
@@ -19,4 +19,7 @@ package() {
   cp "${_source_root}/Kbuild" "${_source_root}/dkms.conf" \
      "${_source_root}/dptf_enabler.c" \
      "${destdir}/"
+
+  install -Dm644 "${_source_root}/${_module}.conf" \
+    "${pkgdir}/usr/lib/modules-load.d/${_module}.conf"
 }

--- a/modules/i2c_designware_spklen/i2c_designware_spklen.conf
+++ b/modules/i2c_designware_spklen/i2c_designware_spklen.conf
@@ -1,0 +1,1 @@
+i2c_designware_spklen

--- a/modules/i2c_designware_spklen/packaging/arch/PKGBUILD
+++ b/modules/i2c_designware_spklen/packaging/arch/PKGBUILD
@@ -19,4 +19,7 @@ package() {
   cp "${_source_root}/Kbuild" "${_source_root}/dkms.conf" \
      "${_source_root}/i2c_designware_spklen.c" \
      "${destdir}/"
+
+  install -Dm644 "${_source_root}/${_module}.conf" \
+    "${pkgdir}/usr/lib/modules-load.d/${_module}.conf"
 }

--- a/modules/minibook_ec/minibook_ec.conf
+++ b/modules/minibook_ec/minibook_ec.conf
@@ -1,0 +1,1 @@
+minibook_ec

--- a/modules/minibook_ec/packaging/arch/PKGBUILD
+++ b/modules/minibook_ec/packaging/arch/PKGBUILD
@@ -19,4 +19,7 @@ package() {
   cp "${_source_root}/Kbuild" "${_source_root}/dkms.conf" \
      "${_source_root}"/*.c "${_source_root}"/*.h \
      "${destdir}/"
+
+  install -Dm644 "${_source_root}/${_module}.conf" \
+    "${pkgdir}/usr/lib/modules-load.d/${_module}.conf"
 }


### PR DESCRIPTION
> **Stacked on #15** — that PR adds the PKGBUILDs this change installs from, so the diff here also shows its commit. Only `7c1792a` belongs to this PR; the diff collapses to six files once #15 lands.

None of the three always-on modules load themselves after installation. `make enable` writes `/etc/modules-load.d/<name>.conf` by hand, which works but leaves the file behind after the module is uninstalled — and a package-based install never runs it at all, so `pacman -S` gives you a module that stays silent until the next manual `modprobe`.

This adds a one-line `<name>.conf` next to each module and installs it from the package to `/usr/lib/modules-load.d/`:

```
modules/minibook_ec/minibook_ec.conf
modules/dptf_enabler/dptf_enabler.conf
modules/i2c_designware_spklen/i2c_designware_spklen.conf
```

Being the vendor directory rather than `/etc`, the file is owned by the package and removed with it, while a user who wants the module *not* to load can still mask it with an empty file of the same name in `/etc/modules-load.d` — the usual systemd override order.

The `.conf` files themselves are plain systemd `modules-load.d` configs with nothing Arch-specific in them, so any other packaging added later can install the same file; only the `install -Dm644` line in the PKGBUILD is distro-specific.

I left the Makefile's `enable`/`disable` targets untouched, since they read as a deliberate opt-in for the from-source path — say the word if you would rather have `enable` install this file instead of echoing into `/etc`.

### Why goodix_ts is left out

It is autoloaded by its bus match, so a `modules-load.d` entry would be redundant:

```
$ modinfo goodix_ts | grep ^alias
alias:          acpi*:GDIX1001:*
alias:          acpi*:GDIX1002:*
alias:          acpi*:GDIX1003:*
alias:          acpi*:GDX9110:*
alias:          i2c:GDIX1001:00
```
