### PR TITLE
Fix goodix_ts DKMS auto-rebuild, thermald status check, doc gaps

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -149,6 +149,18 @@ Verify: `journalctl -u thermald | grep minibook`. See
 
 Screen rotation and tablet mode via dual accelerometers.
 
+Requires the `i2c-dev` and `acpi_call` kernel modules. Without `i2c-dev`, the
+MXC6655 driver cannot open `/dev/i2c-*` and the service exits immediately with
+"No sensors or missing kernel drivers for the sensors". `acpi_call` is needed
+for the EC-level keyboard/touchpad toggle in tablet mode (screen rotation
+itself works without it). Load both and make them persistent:
+
+```
+sudo pacman -S acpi_call-dkms   # or your distro's acpi_call package
+sudo modprobe i2c-dev acpi_call
+printf 'i2c-dev\nacpi_call\n' | sudo tee /etc/modules-load.d/iio-sensor-proxy.conf
+```
+
 ```
 cd iio-sensor-proxy
 make && sudo make install
@@ -188,6 +200,34 @@ static rotation (kernel cmdline, VBT patch, xrandr script) - they will stack.
 
 Verify: `monitor-sensor` and tilt the device. See
 [iio-sensor-proxy.md](docs/iio-sensor-proxy.md) for details.
+
+#### On-screen keyboard (tablet mode)
+
+In tablet mode the physical keyboard is disabled at the EC level (see
+[minibook-ec.md](docs/minibook-ec.md#touchpad-and-keyboard)), so text input
+needs an on-screen keyboard. There is no built-in popup-on-focus mechanism on
+Niri (unlike GNOME/KDE) -- wire one up manually with `switch-events`:
+
+```
+yay -S wvkbd-deskintl
+```
+
+Add to a Niri config file (e.g. `~/.config/niri/cfg/switch-events.kdl`):
+
+```
+switch-events {
+    tablet-mode-on {
+        spawn "wvkbd-deskintl"
+    }
+    tablet-mode-off {
+        spawn "pkill" "-x" "wvkbd-deskintl"
+    }
+}
+```
+
+`wvkbd-deskintl` has no dedicated Polish layout, but every diacritic (ą ć ę ł
+ń ó ś ź ż) is reachable through the "Cmp" (Compose) key: tap `Cmp`, then the
+base letter, then pick the accented variant from the popup that appears.
 
 ### 8. VBT patcher (display refresh rate)
 
@@ -350,6 +390,132 @@ xrandr --output DSI-1 --rotate right
 This is a runtime-only change that does not persist across reboots unless added
 to a startup script or xprofile. It does not affect the boot splash, TTY
 consoles or login screen.
+
+#### Login screen (greetd + noctalia-greeter)
+
+None of the methods above reach the login screen -- it runs as its own,
+separate process before your compositor session even starts. SDDM's default
+X11 greeter has no rotation of its own, and getting its Wayland mode working
+is more trouble than it's worth on this panel (see the aside at the end of
+this section). `greetd` + `noctalia-greeter` is the setup that ended up
+working reliably.
+
+**Prerequisite: `seatd`.** Without it, switching VTs between the greeter and
+an already-running Niri session can wedge Niri's DRM output permanently --
+`journalctl` fills with `Page flip commit failed ... Permission denied` and
+the session never recovers (hard reset required). This happens with *any*
+second compositor grabbing a VT (reproduced with Weston, a second Niri
+instance, and noctalia-greeter's own compositor), not just a Niri-vs-Niri
+conflict -- the actual cause is `libseat` falling back to `logind` for seat
+management, which does not hand DRM master back and forth between VTs
+reliably on this hardware. `seatd` is the seat backend Niri prefers and
+fixes this:
+
+```
+sudo usermod -aG seat "$USER"
+sudo usermod -aG seat greeter   # after installing greetd below, so the user exists
+sudo systemctl enable --now seatd
+sudo reboot
+```
+
+Verify both the greeter and your session picked it up (look for backend
+`seatd`, not `logind`):
+
+```
+journalctl -b --no-pager | grep -i "seat opened"
+```
+
+Do this before touching the greeter config below -- it is not
+Wayland-greeter-specific, plain SDDM+Xorg can wedge the same way if anything
+else on the seat needs a VT switch.
+
+**Install `greetd` and `noctalia-greeter`:**
+
+```
+sudo pacman -S greetd noctalia-greeter
+sudo systemctl disable sddm   # if migrating from SDDM
+sudo systemctl enable greetd
+```
+
+`greetd`'s `greeter` system user needs a real home directory -- by default it
+is `/`, and GTK/Qt-based greeters abort (`SIGABRT`) trying to create
+cache/config directories there:
+
+```
+sudo mkdir -p /var/lib/greeter
+sudo chown greeter:greeter /var/lib/greeter
+sudo usermod -d /var/lib/greeter greeter
+```
+
+`/etc/greetd/config.toml`:
+
+```
+[terminal]
+vt = 1
+
+[default_session]
+command = "/usr/bin/noctalia-greeter-session -- --session niri"
+user = "greeter"
+```
+
+**Rotation and scale** live in `/var/lib/noctalia-greeter/greeter.toml`
+(created automatically, root:greeter-owned, mode `0750` -- edit with `sudo`):
+
+```
+[output]
+transforms = "DSI-1:270"
+scale = 1.25
+```
+
+Both are meant to sync automatically from the Noctalia shell running on your
+desktop session (see `sync.toml` in the same directory) -- set them manually
+here if the sync hasn't happened yet or you don't run Noctalia.
+
+`transforms` (plural) takes a `"<connector>:<value>"` string, `;`-separated
+for multiple outputs (e.g. `"DP-1:normal; HDMI-A-1:270"`). It must be a
+single `[output]` table -- not `[output.DSI-1]` with a singular `transform`
+key, which is silently ignored (no error, the greeter just stays unrotated).
+
+`scale` is different: it's a bare number (`1.25`, not `"DSI-1:1.25"`) and
+applies uniformly to every output -- there is no per-connector equivalent.
+Upstream's own example config also documents a plural `scales` key (per
+connector, same `"name:value"` format as `transforms`), but the packaged
+version at the time of writing (`noctalia-greeter 1.0.0` internally, `1.1.0-1`
+in the CachyOS package) does not recognize it --
+`journalctl -u greetd | grep greeter-config` logs
+`unrecognized key 'output.scales' (ignored)` and silently keeps the
+auto-detected scale (`2` on this panel) instead. Use singular `scale` until
+that lands; check the same log line to confirm your key was actually picked
+up rather than silently ignored either way.
+
+<details>
+<summary>Aside: why not SDDM+Weston, or plain Niri+regreet?</summary>
+
+Both were tried first and worked, technically, but neither was worth keeping:
+
+- **SDDM + Weston**: SDDM's Wayland mode needs a compositor for its
+  `CompositorCommand`. `cage` cannot rotate at all (no CLI flag, and wlroots
+  only exposes the panel-orientation property to compositors that explicitly
+  read it -- cage doesn't). `weston` can, via a `weston.ini` with
+  `transform=rotate-270`, but it's a second, unrelated compositor codebase
+  to configure and keep in sync by hand, and installing it adds a spurious
+  "Weston" entry to session pickers
+  (`/usr/share/wayland-sessions/weston.desktop`, safe to `rm`).
+- **greetd + Niri + regreet**: Niri itself auto-detects the DRM
+  panel-orientation quirk with zero config (same mechanism as the desktop
+  session), which looked ideal -- run Niri as the greeter compositor too.
+  In practice `regreet` (GTK4) needs its own D-Bus session bus or it aborts
+  on startup (wrap it in `dbus-run-session`), and the handoff from the
+  greeter's Niri instance to the real one still shows a brief flash of raw
+  console text during the VT switch -- an inherent property of running two
+  independent compositor processes back to back, not a misconfiguration.
+
+`noctalia-greeter` sidesteps the GTK/D-Bus fragility (it bundles its own
+compositor and handles that internally) at the cost of *not* getting Niri's
+automatic rotation for free -- its compositor is a separate wlroots build,
+so rotation needs the same kind of manual, per-panel config Weston did.
+
+</details>
 
 ### DSI link tearing
 

--- a/docs/iio-sensor-proxy.md
+++ b/docs/iio-sensor-proxy.md
@@ -62,12 +62,23 @@ Polling stops while the lid is closed (regardless of `--lazy` or any claim) and
 resumes when it opens; tablet mode is unaffected. The driver logs each
 transition to the journal: `journalctl -u iio-sensor-proxy | grep 'polling'`.
 
-## Runtime requirement
+## Runtime requirements
+
+The `i2c-dev` kernel module must be loaded. The driver finds the two MXC6655
+accelerometers by opening `/dev/i2c-*`, which only exist once `i2c-dev` is
+loaded -- without it, `find_accels()` finds nothing and the service exits
+immediately with "No sensors or missing kernel drivers for the sensors".
 
 The `acpi_call` kernel module must be loaded for tablet mode transitions (the
 driver calls ACPI method `\_SB.ACMK.LTSM` to toggle the keyboard). If
 `acpi_call` is not available, screen rotation still works but tablet mode
-toggling via ACPI is skipped.
+toggling via ACPI is skipped -- `SW_TABLET_MODE` is still emitted via uinput,
+so most compositors still disable keyboard input at the libinput level, just
+not at the EC level.
+
+Neither module is loaded by default on most distros. Load them and add to
+`/etc/modules-load.d/` for them to persist across reboots -- see
+[GUIDE.md](../GUIDE.md#7-iio-sensor-proxy).
 
 ## Verify
 

--- a/modules/goodix_ts/Makefile
+++ b/modules/goodix_ts/Makefile
@@ -1,7 +1,7 @@
 DKMS_NAME = goodix_ts
 KVER ?= $(shell uname -r | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
 KVER_MM ?= $(shell uname -r | grep -oE '^[0-9]+\.[0-9]+')
-DKMS_VERSION = $(KVER)-minibook1
+DKMS_VERSION = $(KVER).minibook1
 DKMS_DIR = /usr/src/$(DKMS_NAME)-$(DKMS_VERSION)
 KERNEL_GIT = https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain
 TOUCHSCREEN_DIR = drivers/input/touchscreen

--- a/tools/check-status.sh
+++ b/tools/check-status.sh
@@ -13,6 +13,25 @@ readonly STOCK_VBT_CLOCK=1368870
 
 has_cmd() { command -v "$1" &>/dev/null; }
 
+# thermald is commonly installed to /usr/local/sbin (generic `make install`)
+# or /usr/sbin (`make install-arch` via pacman), neither of which is
+# guaranteed to be on a regular user's PATH -- so a bare `command -v thermald`
+# lookup can miss a correctly installed binary. Fall back to known locations.
+find_thermald() {
+  if has_cmd thermald; then
+    command -v thermald
+    return 0
+  fi
+  local candidate
+  for candidate in /usr/local/sbin/thermald /usr/sbin/thermald; do
+    if [[ -x "${candidate}" ]]; then
+      echo "${candidate}"
+      return 0
+    fi
+  done
+  return 1
+}
+
 
 module_loaded() {
   [[ -d "/sys/module/$1" ]]
@@ -500,8 +519,12 @@ check_services() {
   echo "--- services ---"
   echo ""
 
-  local thermald_ver iio_ver
-  thermald_ver="$(thermald --version 2>&1 | head -1 || echo "NOT FOUND")"
+  local thermald_ver iio_ver thermald_bin
+  if thermald_bin="$(find_thermald)"; then
+    thermald_ver="$("${thermald_bin}" --version 2>&1 | head -1)"
+  else
+    thermald_ver="NOT FOUND"
+  fi
   check_service "thermald" "${thermald_ver}"
 
   iio_ver="$(read_iio_version)"


### PR DESCRIPTION
## Summary

Three independent fixes/additions found while running this on a CHUWI MiniBook X after a kernel update broke touchscreen resume behavior:

- **fix(goodix_ts):** `DKMS_VERSION` used a hyphen (`$(KVER)-minibook1`), which pacman's `dkms` hook mis-parses when deriving module name/version from the `/usr/src/<name>-<version>` directory name (it splits on the *last* hyphen). This made the automatic rebuild-on-kernel-update silently fail every time (`Error! Bad return status for module build`), confirmed in `/var/log/pacman.log` across two separate kernel bumps. Switching to a dot fixes the parse without any functional change to the module itself.
- **fix(check-status):** the `thermald` service check called bare `thermald --version`, which fails whenever `/usr/local/sbin` (or `/usr/sbin` for the `install-arch` path) isn't on the invoking user's `PATH` — reporting a correctly installed, correctly patched `thermald` as `NOT FOUND (WRONG)`. Added a small fallback that checks the known install locations.
- **docs:** documented that `iio-sensor-proxy` requires `i2c-dev` (silently exits with "No sensors or missing kernel drivers" otherwise) and `acpi_call` (needed for EC-level tablet-mode keyboard toggle), plus how to wire up an on-screen keyboard for tablet mode on Niri (no popup-on-focus mechanism like GNOME/KDE).

## Test plan

- [x] `goodix_ts`: reproduced the pacman-hook failure on two real kernel updates (7.2.2, 7.2.3), confirmed the fix installs cleanly and the hook's own directory-name regex now parses correctly (verified against `/usr/share/libalpm/scripts/dkms`'s `all_nv_from_kver`)
- [x] `check-status.sh`: confirmed `thermald` now reports correctly (`2.5.11.minibook1, enabled, running`) instead of `(WRONG)`
- [x] Docs changes are additive only, no code affected